### PR TITLE
Add show and hide widgets to loosen up the API

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,49 +5,56 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: "1989d917fbe8e6b39806207df5a3fdd3d816cbd090fac2ce26fb45e9a71476e5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   fancy_password_field:
@@ -66,7 +73,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   flutter_test:
@@ -78,51 +86,58 @@ packages:
     dependency: transitive
     description:
       name: font_awesome_flutter
-      url: "https://pub.dartlang.org"
+      sha256: "8f0ce0204bd0cafa8631536a6f3b7d05d9c16cdc6e8bd807843f917027c5cefd"
+      url: "https://pub.dev"
     source: hosted
     version: "10.2.1"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   password_strength:
     dependency: transitive
     description:
       name: password_strength
-      url: "https://pub.dartlang.org"
+      sha256: "0e51e3d864e37873a1347e658147f88b66e141ee36c58e19828dc5637961e1ce"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -132,58 +147,74 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   step_progress_indicator:
     dependency: "direct main"
     description:
       name: step_progress_indicator
-      url: "https://pub.dartlang.org"
+      sha256: d3b91cb7671ff60460cb3ce0e6937935653aa900a21d00fc58645040005808ab
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.6.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=1.17.0"

--- a/lib/src/fancy_password_field.dart
+++ b/lib/src/fancy_password_field.dart
@@ -17,6 +17,8 @@ class FancyPasswordField extends StatefulWidget {
     this.hasShowHidePassword = true,
     this.showPasswordIcon,
     this.hidePasswordIcon,
+    this.showPasswordWidget,
+    this.hidePasswordWidget,
     this.hasStrengthIndicator = true,
     this.strengthIndicatorBuilder,
     this.hasValidationRules = true,
@@ -67,7 +69,9 @@ class FancyPasswordField extends StatefulWidget {
     this.restorationId,
     this.enableIMEPersonalizedLearning = true,
     this.obscureText,
-  }) : super(key: key);
+  })  : assert(showPasswordIcon == null || showPasswordWidget == null, "showPasswordIcon and showPasswordWidget can't be used at the same time"),
+        assert(hidePasswordIcon == null || hidePasswordWidget == null, "hidePasswordIcon and hidePasswordWidget can't be used at the same time"),
+        super(key: key);
 
   /// Similarly of the [onChanged] property of the [TextFormField].
   final ValueChanged<String>? onChanged;
@@ -96,7 +100,8 @@ class FancyPasswordField extends StatefulWidget {
   /// Indicates wether the widget will have Show/Hide password feature.
   final bool hasShowHidePassword;
 
-  /// The [Icon] that will be displayed to show the password
+  /// The [Icon] that will be displayed to show the password. This field can only be used when the [showPasswordWidget] is null.
+  ///
   /// Only has effect if [hasShowHidePassword] is set true.
   final Icon? showPasswordIcon;
 
@@ -104,6 +109,16 @@ class FancyPasswordField extends StatefulWidget {
   ///
   /// Only has effect if [hasShowHidePassword] is set true.
   final Icon? hidePasswordIcon;
+
+  /// The [Widget] that will be displayed to show the password. This field can only be used when the [showPasswordIcon] field is null.
+  ///
+  /// Only has effect if [hasShowHidePassword] is set true.
+  final Widget? showPasswordWidget;
+
+  /// The [Widget] that will be displayed to hide the password. This field can only be used when the [hidePasswordIcon] field is null.
+  ///
+  /// Only has effect if [hasShowHidePassword] is set true.
+  final Widget? hidePasswordWidget;
 
   /// Wether the widget will show the [StrengthIndicatorWidget]
   final bool hasStrengthIndicator;
@@ -274,9 +289,7 @@ class _FancyPasswordFieldState extends State<FancyPasswordField> {
 
   @override
   void initState() {
-    _passwordController = (widget.passwordController ??
-        FancyPasswordController())
-      ..setRules(widget.validationRules);
+    _passwordController = (widget.passwordController ?? FancyPasswordController())..setRules(widget.validationRules);
     super.initState();
   }
 
@@ -291,8 +304,8 @@ class _FancyPasswordFieldState extends State<FancyPasswordField> {
                       ? widget.decoration?.suffixIcon ??
                           DefaultShowHidePasswordButton(
                             hidePassword: _hidePassword,
-                            showPasswordIcon: widget.showPasswordIcon,
-                            hidePasswordIcon: widget.hidePasswordIcon,
+                            showPasswordIcon: widget.showPasswordIcon ?? widget.showPasswordWidget,
+                            hidePasswordIcon: widget.hidePasswordIcon ?? widget.hidePasswordWidget,
                             onPressed: () {
                               setState(() => _hidePassword = !_hidePassword);
                             },
@@ -303,8 +316,8 @@ class _FancyPasswordFieldState extends State<FancyPasswordField> {
                   suffixIcon: widget.hasShowHidePassword
                       ? DefaultShowHidePasswordButton(
                           hidePassword: _hidePassword,
-                          showPasswordIcon: widget.showPasswordIcon,
-                          hidePasswordIcon: widget.hidePasswordIcon,
+                          showPasswordIcon: widget.showPasswordIcon ?? widget.showPasswordWidget,
+                          hidePasswordIcon: widget.hidePasswordIcon ?? widget.hidePasswordWidget,
                           onPressed: () {
                             setState(() => _hidePassword = !_hidePassword);
                           },
@@ -325,9 +338,7 @@ class _FancyPasswordFieldState extends State<FancyPasswordField> {
               widget.onSaved!(value);
             }
           },
-          validator: widget.validator != null
-              ? (value) => widget.validator!(value)
-              : null,
+          validator: widget.validator != null ? (value) => widget.validator!(value) : null,
           initialValue: widget.initialValue,
           controller: widget.controller,
           focusNode: widget.focusNode,

--- a/lib/src/widget/default_show_hide_password_button.dart
+++ b/lib/src/widget/default_show_hide_password_button.dart
@@ -5,8 +5,8 @@ class DefaultShowHidePasswordButton extends StatelessWidget {
   const DefaultShowHidePasswordButton({
     Key? key,
     required bool hidePassword,
-    Icon? showPasswordIcon,
-    Icon? hidePasswordIcon,
+    Widget? showPasswordIcon,
+    Widget? hidePasswordIcon,
     required Function() onPressed,
   })  : _hidePassword = hidePassword,
         _showPasswordIcon = showPasswordIcon,
@@ -15,8 +15,8 @@ class DefaultShowHidePasswordButton extends StatelessWidget {
         super(key: key);
 
   final bool _hidePassword;
-  final Icon? _showPasswordIcon;
-  final Icon? _hidePasswordIcon;
+  final Widget? _showPasswordIcon;
+  final Widget? _hidePasswordIcon;
   final Function() _onPressed;
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,42 +5,48 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.2"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -52,7 +58,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   flutter_test:
@@ -64,51 +71,58 @@ packages:
     dependency: "direct main"
     description:
       name: font_awesome_flutter
-      url: "https://pub.dartlang.org"
+      sha256: "8f0ce0204bd0cafa8631536a6f3b7d05d9c16cdc6e8bd807843f917027c5cefd"
+      url: "https://pub.dev"
     source: hosted
     version: "10.2.1"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   password_strength:
     dependency: "direct main"
     description:
       name: password_strength
-      url: "https://pub.dartlang.org"
+      sha256: "0e51e3d864e37873a1347e658147f88b66e141ee36c58e19828dc5637961e1ce"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -118,51 +132,66 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.6.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fancy_password_field
 description: A highly customizable password control input widget. It has features such as password strenght and rules validation
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/rodrigobastosv/fancy_password_field
 
 environment:

--- a/test/src/fancy_password_field_test.dart
+++ b/test/src/fancy_password_field_test.dart
@@ -163,4 +163,72 @@ void main() {
       expect(find.byType(ValidationRulesWidget), findsOneWidget);
     },
   );
+
+  testWidgets(
+    'should render hidePasswordWidget when provided',
+    (tester) async {
+      await loadWidget(
+        tester,
+        widget: const FancyPasswordField(
+          hasShowHidePassword: true,
+          hidePasswordWidget: Icon(Icons.visibility_off),
+          // showPasswordWidget: Icon(Icons.visibility),
+        ),
+      );
+
+      expect((tester.widget(find.byType(Icon)) as Icon).icon, Icons.visibility_off);
+    },
+  );
+
+  testWidgets(
+    'should render showPasswordWidget when provided',
+    (tester) async {
+      await loadWidget(
+        tester,
+        widget: const FancyPasswordField(
+          hasShowHidePassword: true,
+          hidePasswordWidget: Icon(Icons.visibility_off),
+          showPasswordWidget: Icon(Icons.visibility),
+        ),
+      );
+
+      await tester.tap(find.byType(Icon));
+
+      await tester.pumpAndSettle();
+
+      expect((tester.widget(find.byType(Icon)) as Icon).icon, Icons.visibility);
+    },
+  );
+
+  testWidgets(
+    'should fail if hidePasswordIcon and hidePasswordWidget are both provided',
+    (tester) async {
+      expect(() async {
+        await loadWidget(
+          tester,
+          widget: FancyPasswordField(
+            hasShowHidePassword: true,
+            hidePasswordIcon: const Icon(Icons.visibility_off),
+            hidePasswordWidget: const Icon(Icons.visibility_off),
+          ),
+        );
+      }, throwsAssertionError);
+    },
+  );
+
+  testWidgets(
+    'should fail if showPasswordIcon and showPasswordWidget are both provided',
+    (tester) async {
+      expect(() async {
+        await loadWidget(
+          tester,
+          widget: FancyPasswordField(
+            hasShowHidePassword: true,
+            showPasswordIcon: const Icon(Icons.visibility_off),
+            showPasswordWidget: const Icon(Icons.visibility_off),
+          ),
+        );
+      }, throwsAssertionError);
+    },
+  );
 }


### PR DESCRIPTION
This PR enables the user to provide more than material `Icon`s without the need to change any of the current types in place.

I'm suggesting expanding the API to accept `showPasswordWidget` and `hidePasswordWidget` widgets.